### PR TITLE
fix: Corregir manejo de timezones y fechas

### DIFF
--- a/src/controllers/metrics/prestadores/PrestadoresMetricsController.ts
+++ b/src/controllers/metrics/prestadores/PrestadoresMetricsController.ts
@@ -8,6 +8,7 @@ import { Prestador } from '../../../models/Prestador';
 import { Solicitud } from '../../../models/Solicitud';
 import { Habilidad } from '../../../models/Habilidad';
 import { Usuario } from '../../../models/Usuario';
+import { formatDateLocal } from '../../../utils/dateUtils';
 
 export class PrestadoresMetricsController extends BaseMetricsCalculator {
   
@@ -340,8 +341,8 @@ export class PrestadoresMetricsController extends BaseMetricsCalculator {
         totalProviders: prestadores.length,
         providerTypes,
         period: {
-          startDate: dateRanges.startDate.toISOString(),
-          endDate: dateRanges.endDate.toISOString()
+          startDate: formatDateLocal(dateRanges.startDate),
+          endDate: formatDateLocal(dateRanges.endDate)
         }
       };
 

--- a/src/controllers/metrics/solicitudes/SolicitudesMetricsController.ts
+++ b/src/controllers/metrics/solicitudes/SolicitudesMetricsController.ts
@@ -5,6 +5,7 @@ import { BaseMetricsCalculator } from '../../../services/BaseMetricsCalculator';
 import { PeriodType, HeatmapResponse, HeatmapPoint, SegmentationFilters } from '../../../types';
 import { AppDataSource } from '../../../config/database';
 import { Solicitud } from '../../../models/Solicitud';
+import { formatDateLocal } from '../../../utils/dateUtils';
 
 export class SolicitudesMetricsController extends BaseMetricsCalculator {
   
@@ -232,8 +233,8 @@ export class SolicitudesMetricsController extends BaseMetricsCalculator {
         data: points,
         totalPoints: points.length,
         period: {
-          startDate: dateRanges.startDate.toISOString().split('T')[0],
-          endDate: dateRanges.endDate.toISOString().split('T')[0]
+          startDate: formatDateLocal(dateRanges.startDate),
+          endDate: formatDateLocal(dateRanges.endDate)
         }
       };
 
@@ -285,8 +286,8 @@ export class SolicitudesMetricsController extends BaseMetricsCalculator {
         data: heatmapPoints,
         totalPoints: heatmapPoints.length,
         period: {
-          startDate: dateRanges.startDate.toISOString(),
-          endDate: dateRanges.endDate.toISOString()
+          startDate: formatDateLocal(dateRanges.startDate),
+          endDate: formatDateLocal(dateRanges.endDate)
         }
       };
 

--- a/src/main/resources/db/migration/V5__Fix_timestamp_columns_to_timestamptz.sql
+++ b/src/main/resources/db/migration/V5__Fix_timestamp_columns_to_timestamptz.sql
@@ -1,0 +1,176 @@
+-- ============================================================
+-- Migración V5: Convertir todas las columnas TIMESTAMP a TIMESTAMPTZ
+-- ============================================================
+-- 
+-- PROBLEMA: Las columnas timestamp fueron creadas como TIMESTAMP (sin timezone)
+-- pero TypeORM espera TIMESTAMPTZ. Esto causa que los timestamps se guarden
+-- y lean sin conversión de timezone.
+--
+-- SOLUCIÓN: Convertir todas las columnas a TIMESTAMPTZ asumiendo que los
+-- datos existentes están en UTC.
+--
+-- IMPORTANTE: Esta migración asume que todos los timestamps actuales
+-- están guardados en UTC y los convierte correctamente a TIMESTAMPTZ.
+-- ============================================================
+
+-- 1. TABLA: events
+ALTER TABLE events 
+  ALTER COLUMN timestamp TYPE TIMESTAMPTZ USING timestamp AT TIME ZONE 'UTC',
+  ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ USING "createdAt" AT TIME ZONE 'UTC',
+  ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ USING "updatedAt" AT TIME ZONE 'UTC';
+
+COMMENT ON COLUMN events.timestamp IS 'Timestamp del evento (TIMESTAMPTZ en UTC)';
+COMMENT ON COLUMN events."createdAt" IS 'Fecha de creación del registro (TIMESTAMPTZ)';
+COMMENT ON COLUMN events."updatedAt" IS 'Fecha de última actualización (TIMESTAMPTZ)';
+
+-- 2. TABLA: usuarios
+ALTER TABLE usuarios
+  ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC';
+
+-- Agregar columna fecha_baja si no existe (algunos entornos pueden no tenerla)
+DO $$ 
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+                   WHERE table_name = 'usuarios' AND column_name = 'fecha_baja') THEN
+        ALTER TABLE usuarios ADD COLUMN fecha_baja TIMESTAMPTZ;
+        COMMENT ON COLUMN usuarios.fecha_baja IS 'Fecha de baja del usuario (TIMESTAMPTZ)';
+    ELSE
+        ALTER TABLE usuarios ALTER COLUMN fecha_baja TYPE TIMESTAMPTZ USING fecha_baja AT TIME ZONE 'UTC';
+    END IF;
+END $$;
+
+-- updated_at puede no existir en la migración original
+DO $$ 
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns 
+               WHERE table_name = 'usuarios' AND column_name = 'updated_at') THEN
+        ALTER TABLE usuarios ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+    END IF;
+END $$;
+
+COMMENT ON COLUMN usuarios.created_at IS 'Fecha de creación (TIMESTAMPTZ)';
+
+-- 3. TABLA: solicitudes
+ALTER TABLE solicitudes
+  ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC',
+  ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+
+-- Agregar fecha_confirmacion si no existe
+DO $$ 
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns 
+                   WHERE table_name = 'solicitudes' AND column_name = 'fecha_confirmacion') THEN
+        ALTER TABLE solicitudes ADD COLUMN fecha_confirmacion TIMESTAMPTZ;
+        COMMENT ON COLUMN solicitudes.fecha_confirmacion IS 'Fecha de confirmación del match (TIMESTAMPTZ)';
+    ELSE
+        ALTER TABLE solicitudes ALTER COLUMN fecha_confirmacion TYPE TIMESTAMPTZ USING fecha_confirmacion AT TIME ZONE 'UTC';
+    END IF;
+END $$;
+
+COMMENT ON COLUMN solicitudes.created_at IS 'Fecha de creación (TIMESTAMPTZ)';
+COMMENT ON COLUMN solicitudes.updated_at IS 'Fecha de actualización (TIMESTAMPTZ)';
+
+-- 4. TABLA: pagos
+ALTER TABLE pagos
+  ALTER COLUMN timestamp_creado TYPE TIMESTAMPTZ USING timestamp_creado AT TIME ZONE 'UTC',
+  ALTER COLUMN timestamp_actual TYPE TIMESTAMPTZ USING timestamp_actual AT TIME ZONE 'UTC',
+  ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC',
+  ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+
+-- captured_at puede tener NULL values
+DO $$ 
+BEGIN
+    ALTER TABLE pagos 
+      ALTER COLUMN captured_at TYPE TIMESTAMPTZ 
+      USING CASE 
+        WHEN captured_at IS NULL THEN NULL 
+        ELSE captured_at AT TIME ZONE 'UTC' 
+      END;
+END $$;
+
+COMMENT ON COLUMN pagos.timestamp_creado IS 'Timestamp de creación del pago (TIMESTAMPTZ)';
+COMMENT ON COLUMN pagos.timestamp_actual IS 'Timestamp de última actualización (TIMESTAMPTZ)';
+COMMENT ON COLUMN pagos.captured_at IS 'Timestamp de captura del pago aprobado (TIMESTAMPTZ)';
+
+-- 5. TABLA: prestadores
+ALTER TABLE prestadores
+  ALTER COLUMN timestamp TYPE TIMESTAMPTZ USING timestamp AT TIME ZONE 'UTC',
+  ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC',
+  ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+
+COMMENT ON COLUMN prestadores.timestamp IS 'Timestamp del evento (TIMESTAMPTZ)';
+
+-- 6. TABLA: servicios
+ALTER TABLE servicios
+  ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC',
+  ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+
+-- timestamp field en servicios
+DO $$ 
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns 
+               WHERE table_name = 'servicios' AND column_name = 'timestamp') THEN
+        ALTER TABLE servicios ALTER COLUMN timestamp TYPE TIMESTAMPTZ USING timestamp AT TIME ZONE 'UTC';
+    END IF;
+END $$;
+
+-- 7. TABLA: habilidades
+ALTER TABLE habilidades
+  ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC',
+  ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+
+-- 8. TABLA: zonas
+ALTER TABLE zonas
+  ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC',
+  ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+
+-- 9. TABLA: rubros
+ALTER TABLE rubros
+  ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC',
+  ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+
+-- 10. TABLA: metrics (si existe)
+DO $$ 
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'metrics') THEN
+        IF EXISTS (SELECT 1 FROM information_schema.columns 
+                   WHERE table_name = 'metrics' AND column_name = 'timestamp') THEN
+            ALTER TABLE metrics ALTER COLUMN timestamp TYPE TIMESTAMPTZ USING timestamp AT TIME ZONE 'UTC';
+        END IF;
+        IF EXISTS (SELECT 1 FROM information_schema.columns 
+                   WHERE table_name = 'metrics' AND column_name = 'createdAt') THEN
+            ALTER TABLE metrics ALTER COLUMN "createdAt" TYPE TIMESTAMPTZ USING "createdAt" AT TIME ZONE 'UTC';
+        END IF;
+        IF EXISTS (SELECT 1 FROM information_schema.columns 
+                   WHERE table_name = 'metrics' AND column_name = 'updatedAt') THEN
+            ALTER TABLE metrics ALTER COLUMN "updatedAt" TYPE TIMESTAMPTZ USING "updatedAt" AT TIME ZONE 'UTC';
+        END IF;
+    END IF;
+END $$;
+
+-- 11. TABLA: feature_flags (si existe)
+DO $$ 
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'feature_flags') THEN
+        IF EXISTS (SELECT 1 FROM information_schema.columns 
+                   WHERE table_name = 'feature_flags' AND column_name = 'created_at') THEN
+            ALTER TABLE feature_flags ALTER COLUMN created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC';
+        END IF;
+        IF EXISTS (SELECT 1 FROM information_schema.columns 
+                   WHERE table_name = 'feature_flags' AND column_name = 'updated_at') THEN
+            ALTER TABLE feature_flags ALTER COLUMN updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+        END IF;
+    END IF;
+END $$;
+
+-- ============================================================
+-- RESULTADO:
+-- Todas las columnas timestamp ahora son TIMESTAMPTZ y contienen
+-- timestamps en UTC con timezone information.
+-- 
+-- PostgreSQL ahora puede:
+-- 1. Guardar timestamps con timezone explícito
+-- 2. Convertir automáticamente según el timezone de la sesión
+-- 3. Comparar fechas correctamente respetando timezones
+-- ============================================================
+

--- a/src/services/BaseMetricsCalculator.ts
+++ b/src/services/BaseMetricsCalculator.ts
@@ -10,6 +10,7 @@ import { Rubro } from '../models/Rubro';
 import { CardMetricResponse, PieMetricResponse, DateRangeFilter, PeriodType, SegmentationFilters } from '../types';
 import { logger } from '../config/logger';
 import { DateRangeService } from './DateRangeService';
+import { formatDateLocal } from '../utils/dateUtils';
 
 /**
  * Clase base para cálculos de métricas usando tablas normalizadas
@@ -224,7 +225,7 @@ export class BaseMetricsCalculator {
         start: new Date(current),
         end: intervalEnd,
         label: formatLabel(current),
-        date: current.toISOString().split('T')[0]
+        date: formatDateLocal(current)
       });
 
       current = nextDate(current);

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,0 +1,40 @@
+/**
+ * Utilidades para manejo de fechas
+ * 
+ * IMPORTANTE: Estas funciones trabajan con timezone local (America/Argentina/Buenos_Aires)
+ * configurado en PostgreSQL y en DateRangeService.
+ */
+
+/**
+ * Formatea una fecha como YYYY-MM-DD en timezone local
+ * (sin conversión a UTC como hace toISOString())
+ * 
+ * @param date Fecha a formatear
+ * @returns String en formato YYYY-MM-DD usando timezone local
+ * 
+ * @example
+ * // date = new Date(2025, 10, 25, 23, 30, 0) // 25 Nov 2025, 23:30 Argentina
+ * formatDateLocal(date) // "2025-11-25" ✅ (correcto, no cambia al día siguiente)
+ * date.toISOString().split('T')[0] // "2025-11-26" ❌ (incorrecto, convierte a UTC)
+ */
+export function formatDateLocal(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Formatea una fecha como YYYY-MM-DD HH:mm:ss en timezone local
+ * 
+ * @param date Fecha a formatear
+ * @returns String en formato YYYY-MM-DD HH:mm:ss usando timezone local
+ */
+export function formatDateTimeLocal(date: Date): string {
+  const datePart = formatDateLocal(date);
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  const seconds = String(date.getSeconds()).padStart(2, '0');
+  return `${datePart} ${hours}:${minutes}:${seconds}`;
+}
+


### PR DESCRIPTION
- Configurar PostgreSQL timezone a America/Argentina/Buenos_Aires
- Actualizar DateRangeService para usar fechas locales
- Crear función formatDateLocal para evitar conversión UTC incorrecta
- Reemplazar toISOString() por formatDateLocal en respuestas API
- Agregar migración V5 para convertir TIMESTAMP a TIMESTAMPTZ

Problema resuelto:
- Los timestamps estaban guardados sin timezone (TIMESTAMP)
- Causaba que fechas después de 21:00 aparecieran en el día siguiente
- Ahora todas las fechas se guardan correctamente en UTC con timezone
- PostgreSQL convierte automáticamente a timezone Argentina configurado

Archivos modificados:
- src/config/database.ts: SET timezone a Argentina
- src/services/DateRangeService.ts: Usar fechas locales
- src/utils/dateUtils.ts: Nueva función formatDateLocal
- src/services/BaseMetricsCalculator.ts: Usar formatDateLocal
- src/controllers/metrics/solicitudes/SolicitudesMetricsController.ts: Usar formatDateLocal
- src/controllers/metrics/prestadores/PrestadoresMetricsController.ts: Usar formatDateLocal
- src/main/resources/db/migration/V5__Fix_timestamp_columns_to_timestamptz.sql: Migración de schema